### PR TITLE
Enable ROS services after first boot

### DIFF
--- a/builder/assets/init_rpi.sh
+++ b/builder/assets/init_rpi.sh
@@ -45,6 +45,10 @@ hostnamectl set-hostname $NEW_HOSTNAME
 sed -i 's/127\.0\.1\.1.*/127.0.1.1\t'${NEW_HOSTNAME}' '${NEW_HOSTNAME}'.local/g' /etc/hosts
 # .local (mdns) hostname added to make it accesable when wlan and ethernet interfaces are down
 
+echo_stamp "Enable ROS services"
+systemctl enable roscore
+systemctl enable clover
+
 echo_stamp "Harware setup"
 /root/hardware_setup.sh
 

--- a/builder/image-ros.sh
+++ b/builder/image-ros.sh
@@ -100,10 +100,6 @@ my_travis_retry pip install -r /home/pi/catkin_ws/src/clover/clover/requirements
 source /opt/ros/melodic/setup.bash
 catkin_make -j2 -DCMAKE_BUILD_TYPE=Release
 
-echo_stamp "Enable ROS services"
-systemctl enable roscore
-systemctl enable clover
-
 echo_stamp "Install clever package (for backwards compatibility)"
 cd /home/pi/catkin_ws/src/clover/builder/assets/clever
 ./setup.py install


### PR DESCRIPTION
ROS services are enabled on first boot. These services serve no purpose when the system is not configured, but still require time to start and stop. This P/R moves enabling these services to the init_rpi.sh script.