### PR TITLE
genmap.py: Add x0 and y0 shift for markers coordinates

### DIFF
--- a/aruco_pose/src/genmap.py
+++ b/aruco_pose/src/genmap.py
@@ -13,7 +13,7 @@
 Generate map file for aruco_map nodelet.
 
 Usage:
-  genmap.py <length> <x> <y> <dist_x> <dist_y> [<first>] [--top-left | --bottom-left]
+  genmap.py <length> <x> <y> <dist_x> <dist_y> [<first>] [<x0>] [<y0>] [--top-left | --bottom-left]
   genmap.py (-h | --help)
 
 Options:
@@ -23,6 +23,8 @@ Options:
   <dist_x>       Distance between markers along X axis
   <dist_y>       Distance between markers along Y axis
   <first>        First marker ID [default: 0]
+  <x0>           X coordinate for the first marker [default: 0]
+  <y0>           Y coordinate for the first marker [default: 0]
   --top-left     First marker is on top-left (default)
   --bottom-left  First marker is on bottom-left
 
@@ -39,20 +41,22 @@ arguments = docopt(__doc__)
 
 length = float(arguments['<length>'])
 first = int(arguments['<first>'] if arguments['<first>'] is not None else 0)
+x0 = float(arguments['<x0>'] if arguments['<x0>'] is not None else 0)
+y0 = float(arguments['<y0>'] if arguments['<y0>'] is not None else 0)
 markers_x = int(arguments['<x>'])
 markers_y = int(arguments['<y>'])
 dist_x = float(arguments['<dist_x>'])
 dist_y = float(arguments['<dist_y>'])
 bottom_left = arguments['--bottom-left']
 
-max_y = (markers_y - 1) * dist_y
+max_y = y0 + (markers_y - 1) * dist_y
 
 print('# id\tlength\tx\ty\tz\trot_z\trot_y\trot_x')
 for y in range(markers_y):
     for x in range(markers_x):
-        pos_x = x * dist_x
-        pos_y = y * dist_y
+        pos_x = x0 + x * dist_x
+        pos_y = y0 + y * dist_y
         if not bottom_left:
             pos_y = max_y - pos_y
-        print('{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t'.format(first, length, pos_x, pos_y, 0, 0, 0, 0))
+        print('{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(first, length, pos_x, pos_y, 0, 0, 0, 0))
         first += 1


### PR DESCRIPTION
Marker generator will be more convenient for generating marker fields from long printed parts, such as:
0  1   2   12 13 14
3  4   5   15 16 17
6  7   8   18 19 20
9  10 11 21 22 23
For this example you have to use genmap for two times: first for markers 0-11 without coordinates shift and second for markers 12-23 with coordinates shift.