### PR TITLE
Fix for errors occurred while running catkin_make

### DIFF
--- a/docs/en/simulation_native.md
+++ b/docs/en/simulation_native.md
@@ -51,7 +51,10 @@ You may want to skip installing the ARM toolchain if you're not planning on comp
 ```
 sudo ./ubuntu.sh --no-nuttx
 ```
-## Patch sitl_gazebo  
+
+## Patch Gazebo plugins
+
+The `sitl_gazebo` package containing required Gazebo plugins needs patching due to recent changes in MAVLink. These patches are already preapplied in the [virtual machine image](simulation_vm.md) and are stored in the VM repository. Run the following commands to download and apply the patches:
 
 ```bash
 cd ~/catkin_ws/src/Firmware/Tools/sitl_gazebo  
@@ -59,6 +62,7 @@ wget https://raw.githubusercontent.com/CopterExpress/clover_vm/master/assets/pat
 patch -p1 < sitl_gazebo.patch
 rm sitl_gazebo.patch  
 ```
+
 ## Install geographiclib datasets
 
 `mavros` requires geographiclib datasets to be present:

--- a/docs/en/simulation_native.md
+++ b/docs/en/simulation_native.md
@@ -51,14 +51,22 @@ You may want to skip installing the ARM toolchain if you're not planning on comp
 ```
 sudo ./ubuntu.sh --no-nuttx
 ```
+## Patch sitl_gazebo  
 
+```bash
+cd ~/catkin_ws/src/Firmware/Tools/sitl_gazebo  
+wget https://raw.githubusercontent.com/CopterExpress/clover_vm/master/assets/patches/sitl_gazebo.patch  
+patch -p1 < sitl_gazebo.patch
+rm sitl_gazebo.patch  
+```
 ## Install geographiclib datasets
 
 `mavros` requires geographiclib datasets to be present:
 
 ```bash
 cd ~
-wget https://raw.githubusercontent.com/mavlink/mavros/6f5bd5a1a67c19c2e605f33de296b1b1be9d02fc/mavros/scripts/install_geographiclib_datasets.sh
+wget https://raw.githubusercontent.com/mavlink/mavros/6f5bd5a1a67c19c2e605f33de296b1b1be9d02fc/mavros/scripts/install_geographiclib_datasets.sh  
+chmod +x ./install_geographiclib_datasets.sh
 sudo ./install_geographiclib_datasets.sh
 rm ./install_geographiclib_datasets.sh
 ```


### PR DESCRIPTION
Fix for errors occurred while running catkin_make in  
* gazebo_opticalflow_plugin.h  
* gazebo_geotagged_images_plugin.cpp  
* gazebo_mavlink_interface.cpp