### PR TITLE
simple_offboard: Relax position_msg timestamp update rules

### DIFF
--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -418,6 +418,7 @@ void publish(const ros::Time stamp)
 
 	if (setpoint_type == POSITION || setpoint_type == NAVIGATE || setpoint_type == NAVIGATE_GLOBAL) {
 		position_msg.header.stamp = stamp;
+
 		if (setpoint_yaw_type == YAW || setpoint_yaw_type == TOWARDS) {
 			position_pub.publish(position_msg);
 

--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -417,8 +417,8 @@ void publish(const ros::Time stamp)
 	}
 
 	if (setpoint_type == POSITION || setpoint_type == NAVIGATE || setpoint_type == NAVIGATE_GLOBAL) {
+		position_msg.header.stamp = stamp;
 		if (setpoint_yaw_type == YAW || setpoint_yaw_type == TOWARDS) {
-			position_msg.header.stamp = stamp;
 			position_pub.publish(position_msg);
 
 		} else {


### PR DESCRIPTION
`position_msg`'s timestamp is not updated if the setpoint type is `YAW_RATE`. This may result in `nav_start` not having a proper timestamp, which, in turn, would result in incorrect `getNavigateSetpoint` behavior.

This P/R addresses the issue.