### PR TITLE
Network autoconfiguration

### DIFF
--- a/builder/assets/dhcpcd.exit-hook
+++ b/builder/assets/dhcpcd.exit-hook
@@ -1,0 +1,6 @@
+# Start dnsmasq if dhcpcd used static config 
+if [ "$interface" = "wlan0" ] && [ "x$profile" = "xstatic_wlan0" ] && [ "$reason" = "STATIC" ]; then
+    echo "Using own network, starting dnsmasq"
+    # Note: We run systemctl in the background to avoid deadlocking on start
+    systemctl start dnsmasq &
+fi

--- a/builder/image-build.sh
+++ b/builder/image-build.sh
@@ -107,6 +107,7 @@ ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} exec ${SCRIPTS_DIR}'/image-software
 # examples
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/examples' '/home/pi/'
 # network setup
+${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/dhcpcd.exit-hook' '/etc'
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} exec ${SCRIPTS_DIR}'/image-network.sh'
 # avahi setup
 ${BUILDER_DIR}/image-chroot.sh ${IMAGE_PATH} copy ${SCRIPTS_DIR}'/assets/avahi-services/sftp-ssh.service' '/etc/avahi/services'

--- a/builder/image-network.sh
+++ b/builder/image-network.sh
@@ -34,11 +34,14 @@ echo_stamp() {
   echo -e ${TEXT}
 }
 
-echo_stamp "#1 Write STATIC to /etc/dhcpcd.conf"
+echo_stamp "#1 Enable fallback profile for wlan0 in /etc/dhcpcd.conf"
 
 cat << EOF >> /etc/dhcpcd.conf
-interface wlan0
+profile static_wlan0
 static ip_address=192.168.11.1/24
+
+interface wlan0
+fallback static_wlan0
 EOF
 
 echo_stamp "#2 Set wpa_supplicant country"


### PR DESCRIPTION
As of now, wireless network reconfiguration requires multiple steps:

 * change `wpa_supplicant`configuration;
 * change `/etc/dhcpcd.conf`;
 * enable/disable `dnsmasq.service` (depending on AP/station config);
 * restart `dhcpcd.service` (or the whole RPi).

This is tedious, and each step may be performed erroneously, resulting in a system that won't bring up the network.

Obviously, we should and can do better than that.

This P/R proposes adding a `dhcpcd` hook and changing `dhcpcd` config to use static IP as a fallback configuration. With this P/R, network reconfiguration is now a two-step process:

* change `wpa_supplicant` configuration;
* restart the whole RPi (not sure about just `dhcpcd.service`).

P/R progress:

- [x] default config changes;
- [ ] test image with this P/R applied;
- [ ] documentation changes;