### PR TITLE
simple_offboard: detect killswitch when auto_arm is set

### DIFF
--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -493,7 +493,7 @@ inline void checkKillSwitch()
 	if (!TIMEOUT(manual_control, state_timeout))
 		throw std::runtime_error("Manual control timeout, can't check kill switch status");
 
-	const KILL_SWITCH_BIT = 12; // TODO: link to source file
+	const int KILL_SWITCH_BIT = 12; // https://github.com/PX4/Firmware/blob/c302514a0809b1765fafd13c014d705446ae1113/src/modules/mavlink/mavlink_messages.cpp#L3975
 	bool kill_switch = manual_control.buttons & (1 << KILL_SWITCH_BIT);
 
 	if (kill_switch)
@@ -527,7 +527,7 @@ bool serve(enum setpoint_type_t sp_type, float x, float y, float z, float vx, fl
 		// Checks
 		checkState();
 
-		if (check_kill_switch) {
+		if (auto_arm && check_kill_switch) {
 			checkKillSwitch();
 		}
 

--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -488,6 +488,18 @@ void publishSetpoint(const ros::TimerEvent& event)
 	publish(event.current_real);
 }
 
+inline void checkKillSwitch()
+{
+	if (!TIMEOUT(manual_control, state_timeout))
+		throw std::runtime_error("Manual control timeout, can't check kill switch status");
+
+	const KILL_SWITCH_BIT = 12; // TODO: link to source file
+	bool kill_switch = manual_control.buttons & (1 << KILL_SWITCH_BIT);
+
+	if (kill_switch)
+		throw std::runtime_error("Kill switch is on");
+}
+
 inline void checkState()
 {
 	if (TIMEOUT(state, state_timeout))
@@ -514,6 +526,10 @@ bool serve(enum setpoint_type_t sp_type, float x, float y, float z, float vx, fl
 
 		// Checks
 		checkState();
+
+		if (check_kill_switch) {
+			checkKillSwitch();
+		}
 
 		// default frame is local frame
 		if (frame_id.empty())

--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -75,7 +75,7 @@ ros::Duration global_position_timeout;
 ros::Duration battery_timeout;
 float default_speed;
 bool auto_release;
-bool land_only_in_offboard, nav_from_sp;
+bool land_only_in_offboard, nav_from_sp, check_kill_switch;
 std::map<string, string> reference_frames;
 
 // Publishers
@@ -836,6 +836,7 @@ int main(int argc, char **argv)
 	nh_priv.param("auto_release", auto_release, true);
 	nh_priv.param("land_only_in_offboard", land_only_in_offboard, true);
 	nh_priv.param("nav_from_sp", nav_from_sp, true);
+	nh_priv.param("check_kill_switch", check_kill_switch, true);
 	nh_priv.param("default_speed", default_speed, 0.5f);
 	nh_priv.param<string>("body_frame", body.child_frame_id, "body");
 	nh_priv.getParam("reference_frames", reference_frames);

--- a/clover/src/simple_offboard.cpp
+++ b/clover/src/simple_offboard.cpp
@@ -36,6 +36,7 @@
 #include <mavros_msgs/Thrust.h>
 #include <mavros_msgs/State.h>
 #include <mavros_msgs/StatusText.h>
+#include <mavros_msgs/ManualControl.h>
 
 #include <clover/GetTelemetry.h>
 #include <clover/Navigate.h>
@@ -122,6 +123,7 @@ enum { YAW, YAW_RATE, TOWARDS } setpoint_yaw_type;
 // Last received telemetry messages
 mavros_msgs::State state;
 mavros_msgs::StatusText statustext;
+mavros_msgs::ManualControl manual_control;
 PoseStamped local_position;
 TwistStamped velocity;
 NavSatFix global_position;
@@ -860,6 +862,7 @@ int main(int argc, char **argv)
 	auto global_position_sub = nh.subscribe("mavros/global_position/global", 1, &handleMessage<NavSatFix, global_position>);
 	auto battery_sub = nh.subscribe("mavros/battery", 1, &handleMessage<BatteryState, battery>);
 	auto statustext_sub = nh.subscribe("mavros/statustext/recv", 1, &handleMessage<mavros_msgs::StatusText, statustext>);
+	auto manual_control_sub = nh.subscribe("mavros/manual_control/control", 1, &handleMessage<mavros_msgs::ManualControl, manual_control>);
 	auto local_position_sub = nh.subscribe("mavros/local_position/pose", 1, &handleLocalPosition);
 
 	// Setpoint publishers


### PR DESCRIPTION
With this change it's possible to detect kill switch: https://github.com/PX4/Firmware/pull/15950.
So will not auto arm, when it's on.