### PR TITLE
Fix XML formatting in generated world when adding ArUco markers

### DIFF
--- a/clover_simulation/src/clover_simulation/world.py
+++ b/clover_simulation/src/clover_simulation/world.py
@@ -5,10 +5,10 @@ import xml.etree.ElementTree as ET
 from string import Template
 
 WORLD_INCLUDE = Template('''
-<include>
-    <uri>model://${model_name}</uri>
-    <pose>${x} ${y} ${z} ${roll} ${pitch} ${yaw}</pose>
-</include>
+    <include>
+      <uri>model://${model_name}</uri>
+      <pose>${x} ${y} ${z} ${roll} ${pitch} ${yaw}</pose>
+    </include>
 ''')
 
 def load_world(world_file):
@@ -32,6 +32,7 @@ def add_model(world, model_name, x, y, z, roll, pitch, yaw, index=0):
         pitch=pitch,
         yaw=yaw
     ))
+    model_elem.tail = '\n    '
     world_elem.insert(index, model_elem)
     return world
 


### PR DESCRIPTION
Changed the way of adding an XML element into the .world file to fix the formatting issue.

This is the most optimal way to add proper indentation and new lines. By default, when editing an XML document this way, the xml.etree.ElementTree module wouldn't add a new line after an inserted element. 

There is another way to build a new XML document. It requires the lxml.etree module. This way you can discard all the original document formatting (whitespaces, line breaks) by parsing it with a custom parser (e.g. parser = etree.XMLParser(remove_blank_text=True)) and build a brand new pretty formatted document by using the write() function with the pretty_print=True argument.
But the downside of this approach is that you lose all the empty lines that separated blocks in the original XML document. Not only this approach requires more change, it also requires the manual recreation of those blank lines which is too much work for such simple task as adding an element to an XML document.