### PR TITLE
docs: fix incorrect table

### DIFF
--- a/docs/ru/assemble_4_2_ws.md
+++ b/docs/ru/assemble_4_2_ws.md
@@ -240,12 +240,27 @@
         <img src="../assets/assembling_soldering_clever_4/raspberry_8.png" width=300 class="zoom border">
     </div>
 
-    | Провод | Пин дальномера |
-    |--------|----------------|
-    | <font color=red>Красный</font> | 5v |
-    | <font color=black>Черный</font> | GND |
-    | <font color=yellow>Желтый</font> | SDA |
-    | <font color=green>Зеленый</font> | SCL |
+<table class=versions>
+     <tr><th>Провод</th><th>Пин дальномера</th></tr>
+     <tr>
+          <td>
+               <font color=red>Красный</font> 
+          </td>
+          <td>5v</td>
+     </tr>
+     <tr>
+          <td><font color=black>Черный</font></td>
+          <td>GND</td>
+     </tr>
+     <tr>
+          <td><font color=yellow>Желтый</font></td>
+          <td>SDA</td>
+     </tr>
+     <tr>
+          <td><font color=green>Зеленый</font> </td>
+          <td>SCL</td>
+     </tr>
+</table>
 
     <div class="image-group">
         <img src="../assets/assembling_soldering_clever_4/raspberry_9.png" width=300 class="zoom border">

--- a/docs/ru/assemble_4_2_ws.md
+++ b/docs/ru/assemble_4_2_ws.md
@@ -240,27 +240,27 @@
         <img src="../assets/assembling_soldering_clever_4/raspberry_8.png" width=300 class="zoom border">
     </div>
 
-<table class=versions>
-     <tr><th>Провод</th><th>Пин дальномера</th></tr>
-     <tr>
-          <td>
-               <font color=red>Красный</font> 
-          </td>
-          <td>5v</td>
-     </tr>
-     <tr>
-          <td><font color=black>Черный</font></td>
-          <td>GND</td>
-     </tr>
-     <tr>
-          <td><font color=yellow>Желтый</font></td>
-          <td>SDA</td>
-     </tr>
-     <tr>
-          <td><font color=green>Зеленый</font> </td>
-          <td>SCL</td>
-     </tr>
-</table>
+   <table class=versions>
+        <tr><th>Провод</th><th>Пин дальномера</th></tr>
+        <tr>
+             <td>
+                  <font color=red>Красный</font>
+             </td>
+             <td>5v</td>
+        </tr>
+        <tr>
+             <td><font color=black>Черный</font></td>
+             <td>GND</td>
+        </tr>
+        <tr>
+             <td><font color=yellow>Желтый</font></td>
+             <td>SDA</td>
+        </tr>
+        <tr>
+             <td><font color=green>Зеленый</font> </td>
+             <td>SCL</td>
+        </tr>
+   </table>
 
     <div class="image-group">
         <img src="../assets/assembling_soldering_clever_4/raspberry_9.png" width=300 class="zoom border">


### PR DESCRIPTION
Fixed incorrect table display in assemble_4_2_ws.md 
Before:
![Скриншот 26-06-2021 183723](https://user-images.githubusercontent.com/46196443/123518249-bdfb9580-d6ad-11eb-91c9-83974ac1d7cf.jpg)
After:
![Скриншот 26-06-2021 183734](https://user-images.githubusercontent.com/46196443/123518258-c784fd80-d6ad-11eb-865a-3f4106c980c7.jpg)
