### PR TITLE
Some fix in VEYE-MIPI-327E cam driver install

### DIFF
--- a/docs/ru/duocam_setup.md
+++ b/docs/ru/duocam_setup.md
@@ -22,13 +22,11 @@ DuoCam включает в себя две камеры: визуальная к
 
 > **Info** Основная статья: http://wiki.veye.cc/index.php/V4L2_mode_for_Raspberry_Pi
 
-Для начала обновите все пакеты в системе и ядро Linux командой:
+Для начала обновите информацию о пакетах командой:
 
 ```bash
-sudo apt update && sudo apt upgrade -y
+sudo apt update
 ```
-
-После этого обязательно перезагрузите Raspberry Pi командой `sudo reboot`.
 
 Далее выполните команды для установки драйвера камеры:
 
@@ -39,7 +37,9 @@ chmod +x *
 sudo ./install_driver.sh veye327
 ```
 
-Перезагрузите Raspberry Pi. После перезагрузки проверьте, что драйвер установился корректно с помощью команд:
+> **Info** Важно, чтобы версия ядра Linux поддерживалась разработчиками драйвера камеры. Узнать свою версию ядра можно командой `uname -r`. Список поддерживаемых версий ядра Linux можно посмотреть в [репозитории драйвера для камеры VEYE-MIPI-327E](https://github.com/veyeimaging/raspberrypi_v4l2/tree/main/release/driver_bin). Откатиться на более старую версию ядра можно командой `sudo rpi-update commit-id` где вместо 'commit-id' нужно подставить id коммита с нужной версией ядра, список всех коммитов можно посмотреть [тут](https://github.com/Hexxeh/rpi-firmware/commits/master). Напрмиер, команда `sudo rpi-update 1fad1d2beceaaf96e84e3f5caa79f52b87332e89` откатывает ядро Linux к версии 5.10.52.
+
+Перезагрузите Raspberry Pi командой `sudo reboot`. После перезагрузки проверьте, что драйвер установился корректно с помощью команд:
 
 ```bash
 dmesg | grep veye

--- a/docs/ru/duocam_setup.md
+++ b/docs/ru/duocam_setup.md
@@ -37,7 +37,7 @@ chmod +x *
 sudo ./install_driver.sh veye327
 ```
 
-> **Info** Важно, чтобы версия ядра Linux поддерживалась разработчиками драйвера камеры. Узнать свою версию ядра можно командой `uname -r`. Список поддерживаемых версий ядра Linux можно посмотреть в [репозитории драйвера для камеры VEYE-MIPI-327E](https://github.com/veyeimaging/raspberrypi_v4l2/tree/main/release/driver_bin). Откатиться на более старую версию ядра можно командой `sudo rpi-update commit-id` где вместо 'commit-id' нужно подставить id коммита с нужной версией ядра, список всех коммитов можно посмотреть [тут](https://github.com/Hexxeh/rpi-firmware/commits/master). Напрмиер, команда `sudo rpi-update 1fad1d2beceaaf96e84e3f5caa79f52b87332e89` откатывает ядро Linux к версии 5.10.52.
+> **Info** Важно, чтобы версия ядра Linux поддерживалась разработчиками драйвера камеры. Узнать свою версию ядра можно командой `uname -r`. Список поддерживаемых версий ядра Linux можно посмотреть в [репозитории драйвера для камеры VEYE-MIPI-327E](https://github.com/veyeimaging/raspberrypi_v4l2/tree/main/release/driver_bin). Откатиться на более старую версию ядра можно командой `sudo rpi-update commit-id` где вместо `commit-id` нужно подставить ID коммита с нужной версией ядра, список всех коммитов можно посмотреть [тут](https://github.com/Hexxeh/rpi-firmware/commits/master). Например, команда `sudo rpi-update 1fad1d2beceaaf96e84e3f5caa79f52b87332e89` откатывает ядро Linux к версии 5.10.52.
 
 Перезагрузите Raspberry Pi командой `sudo reboot`. После перезагрузки проверьте, что драйвер установился корректно с помощью команд:
 


### PR DESCRIPTION
Don't update Linux Kernel before install VEYE-MIPI-327E driver