### PR TITLE
Add missing dependency

### DIFF
--- a/clover/CMakeLists.txt
+++ b/clover/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   geometry_msgs
   sensor_msgs
+  led_msgs
   geographic_msgs
   tf
   tf2


### PR DESCRIPTION
When running `catkin build`, files from `led_msgs` were missing as this package was not listed as a dependency in `CMakeLists.txt`. This commit adds the missing dependency.