### PR TITLE
Deploy docs using build artifacts instead of gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,7 @@ jobs:
           path: _book
 
   deploy-docs:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,16 +4,25 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ '*' ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   docs:
     runs-on: ubuntu-18.04
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -58,11 +67,19 @@ jobs:
           rm -f _book/clover*.pdf
           wget --no-verbose https://clover.coex.tech/clover_ru.pdf -P _book/
           wget --no-verbose https://clover.coex.tech/clover_en.pdf -P _book/
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      - name: Upload artifact
+        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: gh-pages
-          folder: _book
-          clean: true
-          single-commit: true # to avoid multiple copies of large pdf files
+          path: _book
+
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
https://github.blog/changelog/2021-12-16-github-pages-using-github-actions-for-builds-and-deployments-for-public-repositories/