### PR TITLE
docs(ru): add solution for HTTP/2 network errors on px4-autopilot clone

### DIFF
--- a/docs/en/simulation_native.md
+++ b/docs/en/simulation_native.md
@@ -74,6 +74,8 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** You may use more recent PX4 version, but there would be more risk of something would not be working.
 
+> **Note** If clone fails with network error (`fatal: fetch-pack: invalid index-pack output`), set HTTP version 1.1 using `git config --global http.version HTTP/1.1` command (don't forget to return it back after clone using `git config --global http.version HTTP/2`). Alternative solution is cloning the repository and submodules through ssh using `git config --global url."git@github.com:".insteadOf https://github.com/` command (requires a valid ssh key in GitHub profile settings).
+
 ## Install PX4 prerequisites
 
 PX4 comes with its own script for dependency installation. We may as well leverage it:

--- a/docs/en/simulation_native.md
+++ b/docs/en/simulation_native.md
@@ -74,7 +74,7 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** You may use more recent PX4 version, but there would be more risk of something would not be working.
 
-> **Note** If clone fails with network error (`fatal: fetch-pack: invalid index-pack output`), set HTTP version 1.1 using `git config --global http.version HTTP/1.1` command (don't forget to return it back after clone using `git config --global http.version HTTP/2`). Alternative solution is cloning the repository and submodules through ssh using `git config --global url."git@github.com:".insteadOf https://github.com/` command (requires a valid ssh key in GitHub profile settings).
+> **Note** If clone fails with network error (`fatal: fetch-pack: invalid index-pack output`), set HTTP version 1.1 using `git config --global http.version HTTP/1.1` command (don't forget to return it back after clone using `git config --global http.version HTTP/2`). Alternative solution is cloning the repository and submodules through SSH using `git config --global url."git@github.com:".insteadOf https://github.com/` command (requires setting up valid SSH key in GitHub profile settings).
 
 ## Install PX4 prerequisites
 

--- a/docs/en/simulation_native.md
+++ b/docs/en/simulation_native.md
@@ -74,6 +74,8 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** You may use more recent PX4 version, but there would be more risk of something would not be working.
 
+<!-- -->
+
 > **Note** If clone fails with network error (`fatal: fetch-pack: invalid index-pack output`), set HTTP version 1.1 using `git config --global http.version HTTP/1.1` command (don't forget to return it back after clone using `git config --global http.version HTTP/2`). Alternative solution is cloning the repository and submodules through SSH using `git config --global url."git@github.com:".insteadOf https://github.com/` command (requires setting up valid SSH key in GitHub profile settings).
 
 ## Install PX4 prerequisites

--- a/docs/ru/simulation_native.md
+++ b/docs/ru/simulation_native.md
@@ -74,6 +74,8 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** Вы можете использовать более позднюю версию PX4 с большим риском, что что-то не заработает.
 
+<!-- -->
+
 > **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после клонирования верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через SSH командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует генерации и установки SSH ключа в настройках профиля GitHub).
 
 ## Установка зависимостей PX4

--- a/docs/ru/simulation_native.md
+++ b/docs/ru/simulation_native.md
@@ -74,6 +74,9 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** Вы можете использовать более позднюю версию PX4 с большим риском, что что-то не заработает.
 
+> **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после завершени верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через ssh командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует установки ssh ключа в настройках профиля GitHub).
+
+
 ## Установка зависимостей PX4
 
 PX4 имеет свой собственный скрипт для установки зависимостей. Воспользуемся им:

--- a/docs/ru/simulation_native.md
+++ b/docs/ru/simulation_native.md
@@ -74,7 +74,7 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** Вы можете использовать более позднюю версию PX4 с большим риском, что что-то не заработает.
 
-> **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после завершени верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через ssh командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует установки ssh ключа в настройках профиля GitHub).
+> **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после клонирования верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через ssh командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует установки ssh ключа в настройках профиля GitHub).
 
 
 ## Установка зависимостей PX4

--- a/docs/ru/simulation_native.md
+++ b/docs/ru/simulation_native.md
@@ -74,8 +74,7 @@ ln -s ~/PX4-Autopilot/mavlink ~/catkin_ws/src/
 
 > **Hint** Вы можете использовать более позднюю версию PX4 с большим риском, что что-то не заработает.
 
-> **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после клонирования верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через ssh командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует установки ssh ключа в настройках профиля GitHub).
-
+> **Note** Если процесс клонирования завершится с ошибкой сети (`fatal: fetch-pack: invalid index-pack output`), используйте версию HTTP 1.1 `git config --global http.version HTTP/1.1` (после клонирования верните 2 версию командой `git config --global http.version HTTP/2`). Альтернативным решением будет принудительное клонирование репозитория и субмодулей через SSH командой `git config --global url."git@github.com:".insteadOf https://github.com/` (требует генерации и установки SSH ключа в настройках профиля GitHub).
 
 ## Установка зависимостей PX4
 


### PR DESCRIPTION
При слабой сети невозможно клонировать репозиторий PX4 - зависимости слетают с ошибкой сети
Летят ошибки подобного рода:
```
Cloning into '/Users/belyaev-dev/PX4-Autopilot/Tools/sitl_gazebo'...
error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)
error: 8146 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
fatal: clone of 'https://github.com/PX4/PX4-SITL_gazebo.git' into submodule path '/Users/belyaev-dev/PX4-Autopilot/Tools/sitl_gazebo' failed
Failed to clone 'Tools/sitl_gazebo'. Retry scheduled
Cloning into '/Users/belyaev-dev/PX4-Autopilot/platforms/nuttx/NuttX/nuttx'...
error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)
error: 158 bytes of body are still expected
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

Сборка, соответственно, не проходит:
```
CMake Error at /opt/ros/noetic/share/catkin/cmake/catkin_workspace.cmake:100 (message):
  This workspace contains non-catkin packages in it, and catkin cannot build
  a non-homogeneous workspace without isolation.  Try the
  'catkin_make_isolated' command instead.
Call Stack (most recent call first):
  CMakeLists.txt:69 (catkin_workspace)


-- Configuring incomplete, errors occurred!
See also "/home/clover/catkin_ws/build/CMakeFiles/CMakeOutput.log".
See also "/home/clover/catkin_ws/build/CMakeFiles/CMakeError.log".
make: *** [Makefile:320: cmake_check_build_system] Ошибка 1
Invoking "make cmake_check_build_system" failed
```